### PR TITLE
Changed default in condor_download to remove=FALSE

### DIFF
--- a/R/condor_download.R
+++ b/R/condor_download.R
@@ -50,7 +50,7 @@
 
 condor_download <- function(run.dir=NULL, top.dir="condor", local.dir=".",
                             pattern="End.tar.gz|condor.*(err|log|out)$",
-                            overwrite=FALSE, remove=TRUE, untar.end=TRUE,
+                            overwrite=FALSE, remove=FALSE, untar.end=TRUE,
                             session=NULL)
 {
   # Expand dot so basename() works


### PR DESCRIPTION
Maybe remove=TRUE is too aggressive if there are important files not included in the End.tar.gz